### PR TITLE
Breaking API Updates for Week #4

### DIFF
--- a/app.py
+++ b/app.py
@@ -145,8 +145,7 @@ def GET_settings():
     return jsonify({
         "width": board["width"],
         "height": board["height"],
-        "palette": board["palette"],
-        "pixel_rate": board_manager.get_pixel_rate()
+        "palette": board["palette"]
     })
 
 

--- a/servers.py
+++ b/servers.py
@@ -57,7 +57,7 @@ class ServerManager:
         # Delete the server in the database
         self.collection.delete_one({"_id": ObjectId(id)})
 
-    def use_server(self, id):
+    def use_server(self, id, updateTimeout=True):
         obj_id = ObjectId(id)
 
         # Get the server from the cache
@@ -77,16 +77,18 @@ class ServerManager:
         if found["timeout_time"] > now:
             return (found["timeout_time"] - now).total_seconds()
 
-        # Update the timeout_time and return 0 (no time needed)
-        # In cache
-        next_time = now + \
-            timedelta(milliseconds=self.board_manager.get_pixel_rate())
-        found["timeout_time"] = next_time
-        # In DB
-        self.collection.update_one(
-            {"_id": ObjectId(id)},
-            {"$set": {"timeout_time": next_time}}
-        )
+        # Update the timeout_time when requested
+        if updateTimeout:
+            # In cache
+            next_time = now + timedelta(milliseconds=self.board_manager.get_pixel_rate())
+            found["timeout_time"] = next_time
+            # In DB
+            self.collection.update_one(
+                {"_id": ObjectId(id)},
+                {"$set": {"timeout_time": next_time}}
+            )
+
+        # Return valid time for update (0ms)
         return 0
 
     def get_servers(self):

--- a/static/js/pixelboard.js
+++ b/static/js/pixelboard.js
@@ -26,7 +26,7 @@ let initBoard = function() {
   document.getElementById("pixelboard").appendChild(_canvas);
 
   // Load the current board edits onto this instance of the canvas:
-  fetch("/pixels")
+  fetch("/frontend-pixels")
   .then((response) => response.json())
   .then((data) => {
     let ctx = _canvas.getContext("2d");


### PR DESCRIPTION
This PR contains two API changes discussed in lecture that will require changes to PGs for Week #4:
1. The `/settings` route no longer returns `pixel_rate`.  Instead, `/update-pixel` now returns `rate`.  This new `rate` should be used as the amount of time before a PG sends the next `update-pixel`.
2. The `/pixels` route now requires an `id` (identical to the `/update-pixel` route) to rate-limit buggy PGs from requesting the board more than once /update.  A request to `/pixels` can only be made when a PG is able to update the pixel board.

Before merging this to `main`, I'd like to make sure others don't see any issues with these changes and that this should be a complete set of breaking API changes we would need before the final project presentation on Dec. 13.
